### PR TITLE
Update Twisted site and fix Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Next.js app
-        run: npm run build
-
       - name: Build OpenNext worker bundle
-        run: npx @opennextjs/cloudflare build --skipBuild
+        run: npx opennextjs-cloudflare build
+
+      - name: Verify OpenNext worker bundle
+        run: test -f .open-next/worker.js && test -d .open-next/assets
 
       - name: Set Square access token secret
         run: printf "%s" "$SQUARE_ACCESS_TOKEN" | npx wrangler secret put SQUARE_ACCESS_TOKEN
@@ -38,7 +38,7 @@ jobs:
           SQUARE_ACCESS_TOKEN: ${{ secrets.SQUARE_ACCESS_TOKEN }}
 
       - name: Deploy to Cloudflare Workers
-        run: npx wrangler deploy
+        run: npx wrangler deploy --config wrangler.jsonc
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Updates the Twisted Custom Leather site for launch and fixes the Cloudflare GitHub Actions deploy failure.

## Changes

- Adds Square custom order checkout flow
- Adds featured leather work section and selected product photos
- Updates product content, pricing, SEO metadata, sitemap, robots file, and business schema
- Adds active contact email links for Connie and Randy
- Fixes Cloudflare deploy workflow by removing `--skipBuild` from the OpenNext build step
- Deploy now runs `npx opennextjs-cloudflare build` before `npx wrangler deploy --config wrangler.jsonc`

## Fix

The previous workflow failed because OpenNext was run with `--skipBuild`, but the required `.next/standalone` output was not present. Letting OpenNext run the build should create the needed `.open-next/worker.js` bundle before Wrangler deploys.

## Validation

- Local branch is clean and pushed to `origin/codex/twisted-launch`