### PR TITLE
Fix D1 binding for Cloudflare deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           SQUARE_ACCESS_TOKEN: ${{ secrets.SQUARE_ACCESS_TOKEN }}
 
+      - name: Apply D1 schema
+        run: npx wrangler d1 execute twisted-newsletter --remote --file=./schema.sql --config wrangler.jsonc
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy to Cloudflare Workers
         run: npx wrangler deploy --config wrangler.jsonc
         env:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -36,7 +36,7 @@
 		{
 			"binding": "DB",
 			"database_name": "twisted-newsletter",
-			"database_id": "b3b64ce4-8731-4ffe-ab46-f66d722dbc2c"
+			"database_id": "0463a12e-0924-4856-a8ba-42a0c94e8287"
 		}
 	],
 	"observability": {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,7 +29,7 @@ service = "twisted"
 [[d1_databases]]
 binding = "DB"
 database_name = "twisted-newsletter"
-database_id = "b3b64ce4-8731-4ffe-ab46-f66d722dbc2c"
+database_id = "0463a12e-0924-4856-a8ba-42a0c94e8287"
 
 # Observability - Logs
 [observability]


### PR DESCRIPTION
## Summary

Fixes the Cloudflare deploy failure caused by the Worker config pointing to a D1 database ID that does not exist in the Minted/Serviceflowagi Cloudflare account.

## Changes

- Updates the `twisted-newsletter` D1 database ID in `wrangler.jsonc`
- Updates the matching D1 database ID in `wrangler.toml`
- Adds a GitHub Actions step to apply `schema.sql` before deploy

## Why

The previous deploy uploaded the new static assets successfully, but the Worker publish failed because the configured D1 database was not found.

## Validation

The schema file already includes the required newsletter, popup, customer, conversation notes, and conversation orders tables.