### PR TITLE
Add featured work photo popup

### DIFF
--- a/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
+++ b/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
@@ -1,0 +1,517 @@
+# Featured Work Photo Popup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every Featured Leather Work card open its own larger, uncropped photo while preserving the four existing Google Photos albums through a View Full Album action.
+
+**Architecture:** Keep the current seven-item data array in the server-rendered `FeaturedWork` section and pass it to one focused client component. The client component owns card selection, the accessible modal dialog, keyboard/focus behavior, and the optional album action; a separate pure model owns wraparound index and focus calculations so those rules can be tested without a browser.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Tailwind CSS, Node.js built-in test runner, OpenNext for Cloudflare, Wrangler.
+
+## Global Constraints
+
+- All seven current Featured Work cards must open a larger photo.
+- The larger image must use the same source and alternative text as its card and render with `object-contain`.
+- Previous and Next navigation must wrap across all seven photos.
+- Escape, Left Arrow, Right Arrow, backdrop close, focus trapping, focus restoration, body scroll locking, and body scroll restoration are required.
+- Only the four items that already have `href` values may show **View Full Album**.
+- All four current Google Photos URLs must remain byte-for-byte unchanged.
+- The header menu, custom-order section, and unrelated pages must not change.
+- No new runtime dependency may be added.
+
+---
+
+## File Structure
+
+- Create `src/components/featuredWorkLightboxModel.ts`: pure index and focus-navigation functions.
+- Create `src/components/FeaturedWorkLightbox.tsx`: client-side cards and accessible popup.
+- Modify `src/components/FeaturedWork.tsx`: export a serializable item type, preserve the current data, and delegate rendering to the client component.
+- Create `scripts/featured-work-lightbox.test.cjs`: model, component-contract, and integration-contract tests.
+
+### Task 1: Pure Lightbox Navigation Model
+
+**Files:**
+- Create: `src/components/featuredWorkLightboxModel.ts`
+- Create: `scripts/featured-work-lightbox.test.cjs`
+
+**Interfaces:**
+- Produces: `openFeaturedPhoto(count: number, requestedIndex: number): number | null`
+- Produces: `previousFeaturedPhoto(currentIndex: number, count: number): number | null`
+- Produces: `nextFeaturedPhoto(currentIndex: number, count: number): number | null`
+- Produces: `nextFeaturedFocusIndex(currentIndex: number, focusableCount: number, moveBackward: boolean): number | null`
+
+- [ ] **Step 1: Write the failing model tests**
+
+Create the test harness and tests:
+
+```js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+const root = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+function loadTypeScriptModule(file) {
+  const javascript = ts.transpileModule(read(file), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const sandbox = { exports: {}, module: { exports: {} } };
+  sandbox.module.exports = sandbox.exports;
+  vm.runInNewContext(javascript, sandbox, { filename: file });
+  return sandbox.exports;
+}
+
+test('opens only valid featured photos', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.openFeaturedPhoto(7, 0), 0);
+  assert.equal(model.openFeaturedPhoto(7, 6), 6);
+  assert.equal(model.openFeaturedPhoto(7, -1), null);
+  assert.equal(model.openFeaturedPhoto(7, 7), null);
+  assert.equal(model.openFeaturedPhoto(0, 0), null);
+});
+
+test('featured photo navigation wraps in both directions', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.nextFeaturedPhoto(6, 7), 0);
+  assert.equal(model.previousFeaturedPhoto(0, 7), 6);
+  assert.equal(model.nextFeaturedPhoto(2, 7), 3);
+  assert.equal(model.previousFeaturedPhoto(2, 7), 1);
+});
+
+test('featured popup focus cycles and recovers outside focus', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.nextFeaturedFocusIndex(2, 3, false), 0);
+  assert.equal(model.nextFeaturedFocusIndex(0, 3, true), 2);
+  assert.equal(model.nextFeaturedFocusIndex(-1, 3, false), 0);
+  assert.equal(model.nextFeaturedFocusIndex(-1, 3, true), 2);
+  assert.equal(model.nextFeaturedFocusIndex(0, 0, false), null);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the expected failure**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: FAIL because `src/components/featuredWorkLightboxModel.ts` does not exist.
+
+- [ ] **Step 3: Implement the pure model**
+
+Create:
+
+```ts
+export type FeaturedPhotoIndex = number | null;
+
+export function openFeaturedPhoto(count: number, requestedIndex: number): FeaturedPhotoIndex {
+  return Number.isInteger(requestedIndex)
+    && requestedIndex >= 0
+    && requestedIndex < count
+    ? requestedIndex
+    : null;
+}
+
+export function previousFeaturedPhoto(currentIndex: number, count: number): FeaturedPhotoIndex {
+  return count > 0 ? (currentIndex - 1 + count) % count : null;
+}
+
+export function nextFeaturedPhoto(currentIndex: number, count: number): FeaturedPhotoIndex {
+  return count > 0 ? (currentIndex + 1) % count : null;
+}
+
+export function nextFeaturedFocusIndex(
+  currentIndex: number,
+  focusableCount: number,
+  moveBackward: boolean,
+): FeaturedPhotoIndex {
+  if (focusableCount <= 0) return null;
+  if (currentIndex < 0 || currentIndex >= focusableCount) {
+    return moveBackward ? focusableCount - 1 : 0;
+  }
+  return (currentIndex + (moveBackward ? -1 : 1) + focusableCount) % focusableCount;
+}
+```
+
+- [ ] **Step 4: Run the model tests**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit the model and tests**
+
+```bash
+git add scripts/featured-work-lightbox.test.cjs src/components/featuredWorkLightboxModel.ts
+git commit -m "test: define featured work lightbox behavior"
+```
+
+### Task 2: Accessible Featured Work Popup Component
+
+**Files:**
+- Create: `src/components/FeaturedWorkLightbox.tsx`
+- Modify: `scripts/featured-work-lightbox.test.cjs`
+
+**Interfaces:**
+- Consumes: the four pure functions from Task 1.
+- Consumes: `FeaturedWorkItem[]` with `src`, `alt`, `title`, `category`, `width`, `height`, optional `position`, optional `href`, and optional `span`.
+- Produces: `FeaturedWorkLightbox({ items }: { items: FeaturedWorkItem[] })`.
+
+- [ ] **Step 1: Append a failing component-contract test**
+
+```js
+test('featured work popup exposes accessible controls and the optional album action', () => {
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  assert.match(component, /'use client'/);
+  assert.match(component, /role="dialog"/);
+  assert.match(component, /aria-modal="true"/);
+  assert.match(component, /aria-label="Close larger image"/);
+  assert.match(component, /aria-label="Previous image"/);
+  assert.match(component, /aria-label="Next image"/);
+  assert.match(component, /View Full Album/);
+  assert.match(component, /selectedItem\.href/);
+  assert.match(component, /event\.key === 'Escape'/);
+  assert.match(component, /event\.key === 'ArrowLeft'/);
+  assert.match(component, /event\.key === 'ArrowRight'/);
+  assert.match(component, /object-contain/);
+  assert.match(component, /document\.body\.style\.overflow = 'hidden'/);
+  assert.match(component, /sibling\.setAttribute\('inert', ''\)/);
+  assert.match(component, /window\.scrollTo/);
+  assert.match(component, /opener\?\.focus\(\)/);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the expected failure**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: the existing 3 tests PASS and the new test FAILS because the component file is missing.
+
+- [ ] **Step 3: Implement the client component**
+
+Implement these exact behaviors in `FeaturedWorkLightbox.tsx`:
+
+```tsx
+'use client';
+
+import Image from 'next/image';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { FeaturedWorkItem } from '@/components/FeaturedWork';
+import {
+  nextFeaturedFocusIndex,
+  nextFeaturedPhoto,
+  openFeaturedPhoto,
+  previousFeaturedPhoto,
+} from '@/components/featuredWorkLightboxModel';
+
+const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+type BackgroundState = {
+  element: HTMLElement;
+  inert: boolean;
+  ariaHidden: string | null;
+};
+
+function makeBackgroundInert(dialog: HTMLElement) {
+  const states: BackgroundState[] = [];
+  let foreground: HTMLElement = dialog;
+  while (foreground.parentElement) {
+    const parent = foreground.parentElement;
+    for (const sibling of Array.from(parent.children)) {
+      if (sibling === foreground || !(sibling instanceof HTMLElement)) continue;
+      states.push({
+        element: sibling,
+        inert: sibling.hasAttribute('inert'),
+        ariaHidden: sibling.getAttribute('aria-hidden'),
+      });
+      sibling.setAttribute('inert', '');
+      sibling.setAttribute('aria-hidden', 'true');
+    }
+    if (parent === document.body) break;
+    foreground = parent;
+  }
+  return () => states.forEach(({ element, inert, ariaHidden }) => {
+    if (!inert) element.removeAttribute('inert');
+    if (ariaHidden === null) element.removeAttribute('aria-hidden');
+    else element.setAttribute('aria-hidden', ariaHidden);
+  });
+}
+
+export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkItem[] }) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const openerRef = useRef<HTMLButtonElement | null>(null);
+  const previousOverflow = useRef('');
+  const scrollPosition = useRef({ x: 0, y: 0 });
+  const captionId = useId();
+  const selectedItem = selectedIndex === null ? null : items[selectedIndex] ?? null;
+
+  const close = useCallback(() => {
+    const opener = openerRef.current;
+    setSelectedIndex(null);
+    openerRef.current = null;
+    requestAnimationFrame(() => {
+      opener?.focus();
+      window.scrollTo(scrollPosition.current.x, scrollPosition.current.y);
+    });
+  }, []);
+
+  const previous = useCallback(() => {
+    setSelectedIndex((current) => current === null ? null : previousFeaturedPhoto(current, items.length));
+  }, [items.length]);
+
+  const next = useCallback(() => {
+    setSelectedIndex((current) => current === null ? null : nextFeaturedPhoto(current, items.length));
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    previousOverflow.current = document.body.style.overflow;
+    const restoreBackground = dialogRef.current ? makeBackgroundInert(dialogRef.current) : () => {};
+    document.body.style.overflow = 'hidden';
+    closeRef.current?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow.current;
+      restoreBackground();
+    };
+  }, [selectedItem]);
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+      if (event.key === 'ArrowLeft') previous();
+      if (event.key === 'ArrowRight') next();
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusable = Array.from(dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector));
+        const current = focusable.indexOf(document.activeElement as HTMLElement);
+        const target = nextFeaturedFocusIndex(current, focusable.length, event.shiftKey);
+        if (target !== null) {
+          event.preventDefault();
+          focusable[target].focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [close, next, previous, selectedItem]);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5">
+        {items.map((item, index) => (
+          <button
+            key={item.title}
+            type="button"
+            aria-label={`View larger: ${item.title}`}
+            onClick={(event) => {
+              const nextIndex = openFeaturedPhoto(items.length, index);
+              if (nextIndex === null) return;
+              openerRef.current = event.currentTarget;
+              scrollPosition.current = { x: window.scrollX, y: window.scrollY };
+              setSelectedIndex(nextIndex);
+            }}
+            className="group text-left cursor-zoom-in focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-copper"
+          >
+            <article className={`relative overflow-hidden rounded-lg border border-copper/30 bg-wood-dark/60 min-h-[18rem] ${item.span ?? ''}`}>
+              {item.src.startsWith('http') ? (
+                <img src={item.src} alt={item.alt} className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" style={{ objectPosition: item.position ?? 'center' }} />
+              ) : (
+                <Image src={item.src} alt={item.alt} width={item.width} height={item.height} className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" style={{ objectPosition: item.position ?? 'center' }} sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw" />
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-wood-dark/80 via-wood-dark/10 to-transparent" />
+              <div className="absolute bottom-4 left-4 right-4">
+                <p className="text-copper-light text-sm font-bold uppercase">{item.category}</p>
+                <h3 className="heading-western text-2xl text-cream">{item.title}</h3>
+              </div>
+            </article>
+          </button>
+        ))}
+      </div>
+
+      {selectedItem && (
+        <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby={captionId} onClick={(event) => { if (event.target === event.currentTarget) close(); }} className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 p-3 sm:p-6">
+          <button ref={closeRef} type="button" aria-label="Close larger image" onClick={close} className="absolute right-3 top-3 z-10 h-12 w-12 rounded-full border border-copper bg-charcoal/90 text-3xl text-cream">×</button>
+          <button type="button" aria-label="Previous image" onClick={previous} className="absolute left-2 top-1/2 z-10 h-14 w-12 -translate-y-1/2 rounded-full border border-copper bg-charcoal/90 text-4xl text-cream sm:left-5">‹</button>
+          <figure className="flex max-h-full max-w-6xl flex-col items-center gap-3 px-10 sm:px-16">
+            <img src={selectedItem.src} alt={selectedItem.alt} className="max-h-[calc(100vh-10rem)] max-w-full h-auto w-auto object-contain" />
+            <figcaption id={captionId} className="text-center">
+              <p className="text-copper-light text-sm font-bold uppercase">{selectedItem.category}</p>
+              <p className="heading-western text-xl text-cream">{selectedItem.title}</p>
+            </figcaption>
+            {selectedItem.href && <a href={selectedItem.href} target="_blank" rel="noopener noreferrer" className="rounded-lg bg-copper px-5 py-3 font-bold text-charcoal hover:bg-cream">View Full Album</a>}
+          </figure>
+          <button type="button" aria-label="Next image" onClick={next} className="absolute right-2 top-1/2 z-10 h-14 w-12 -translate-y-1/2 rounded-full border border-copper bg-charcoal/90 text-4xl text-cream sm:right-5">›</button>
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Run the focused tests and type check**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: 4 tests PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Commit the popup component**
+
+```bash
+git add scripts/featured-work-lightbox.test.cjs src/components/FeaturedWorkLightbox.tsx
+git commit -m "feat: add accessible featured work photo popup"
+```
+
+### Task 3: Integrate the Popup Without Changing Album Destinations
+
+**Files:**
+- Modify: `src/components/FeaturedWork.tsx`
+- Modify: `scripts/featured-work-lightbox.test.cjs`
+
+**Interfaces:**
+- Produces: exported `FeaturedWorkItem` type consumed by Task 2.
+- Passes: the unchanged `featuredWork` array to `<FeaturedWorkLightbox items={featuredWork} />`.
+
+- [ ] **Step 1: Append a failing integration test**
+
+```js
+test('all seven featured cards use the popup and existing album links remain unchanged', () => {
+  const featured = read('src/components/FeaturedWork.tsx');
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  const hrefs = [...featured.matchAll(/href: '([^']+)'/g)].map((match) => match[1]);
+  assert.match(featured, /import FeaturedWorkLightbox/);
+  assert.match(featured, /<FeaturedWorkLightbox items=\{featuredWork\} \/>/);
+  assert.equal((featured.match(/title: '/g) || []).length, 7);
+  assert.deepEqual(hrefs, [
+    'https://photos.app.goo.gl/GpcrR32WbqrkSV4L7',
+    'https://photos.google.com/share/AF1QipOsNxODm1-e7A7G3G6ZEPn-cshXXMuZRXZXyykPdt4nqefNbiUnD5bRCaW32J-fsg?key=RFJLS0hBckVXTmpubFdBU0xGbzNjSWFiXzR2VnVn',
+    'https://photos.google.com/share/AF1QipPzOOqKXTMznO6pcbD_tzOVFen160_3j2S1ndp848nNXufyX3sKbKXxPNT_lbFSwA/photo/AF1QipMAfvfW-Iggd2w43t0R_LjXdGapeanTWw0qlyfS?key=QWpuY19GY1BIWWg0bndnZnFRdmY1bmZNME40RDl3',
+    'https://photos.app.goo.gl/LTtAmZFpcWxB893j2',
+  ]);
+  assert.match(component, /target="_blank"/);
+  assert.match(component, /rel="noopener noreferrer"/);
+});
+```
+
+- [ ] **Step 2: Run the test and verify the expected failure**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: the integration test FAILS because `FeaturedWork.tsx` does not yet delegate to the popup component.
+
+- [ ] **Step 3: Make the minimal integration change**
+
+At the top of `FeaturedWork.tsx`, remove the now-unused `Image` import and add:
+
+```tsx
+import FeaturedWorkLightbox from '@/components/FeaturedWorkLightbox';
+
+export type FeaturedWorkItem = {
+  src: string;
+  alt: string;
+  title: string;
+  category: string;
+  width: number;
+  height: number;
+  span?: string;
+  position?: string;
+  href?: string;
+};
+```
+
+Change the existing array declaration from `const featuredWork = [` to `const featuredWork: FeaturedWorkItem[] = [`. Leave every one of the seven existing object literals byte-for-byte unchanged.
+
+Replace only the existing card grid and its inline `map` with:
+
+```tsx
+<FeaturedWorkLightbox items={featuredWork} />
+```
+
+Do not edit any item source, title, category, dimensions, position, or album URL.
+
+- [ ] **Step 4: Run focused and project verification**
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs`
+
+Expected: 5 tests PASS.
+
+Run: `npx tsc --noEmit`
+
+Expected: exit code 0.
+
+Run: `npm run build`
+
+Expected: Next.js production build succeeds and the homepage is generated without errors.
+
+- [ ] **Step 5: Commit the integration**
+
+```bash
+git add scripts/featured-work-lightbox.test.cjs src/components/FeaturedWork.tsx
+git commit -m "feat: open featured work photos in popup"
+```
+
+### Task 4: Production Verification and Publication
+
+**Files:**
+- Verify only; no source file is expected to change.
+
+**Interfaces:**
+- Consumes: the completed Build 1 branch.
+- Produces: a reviewed GitHub change merged to `main`, followed by a successful Cloudflare deployment.
+
+- [ ] **Step 1: Verify the complete local change set**
+
+Run: `git diff --check origin/main...HEAD`
+
+Expected: no whitespace errors.
+
+Run: `node --test scripts/featured-work-lightbox.test.cjs && npx tsc --noEmit && npm run build`
+
+Expected: all tests pass, type check exits 0, and production build succeeds.
+
+- [ ] **Step 2: Build the Cloudflare bundle and run a deployment dry run**
+
+Run: `npx opennextjs-cloudflare build`
+
+Expected: `.open-next/worker.js` and `.open-next/assets` are created.
+
+Run: `npx wrangler deploy --config wrangler.jsonc --dry-run`
+
+Expected: Wrangler validates and packages the `twisted` Worker without publishing.
+
+- [ ] **Step 3: Push the reviewed branch and merge it without replacing newer main content**
+
+```bash
+git push -u origin codex/build1-featured-popup
+gh pr create --base main --head codex/build1-featured-popup --title "Add featured work photo popup" --body-file .superpowers/pr-body.md
+gh pr merge --merge --delete-branch
+```
+
+Expected: the pull request reports a clean merge. If GitHub reports a conflict or `main` moved, stop publication, merge the latest `origin/main` into the branch, re-run Steps 1 and 2, and only then merge.
+
+- [ ] **Step 4: Confirm the production deployment**
+
+Run: `gh run list --workflow deploy.yml --branch main --limit 1`
+
+Expected: the newest workflow run completes successfully.
+
+- [ ] **Step 5: Smoke-test the live website**
+
+At `https://twistedcustomleather.com/`, verify:
+
+1. Each of the seven Featured Leather Work cards opens its matching larger image.
+2. Previous and Next reach all seven images and wrap at both ends.
+3. Escape, close button, and backdrop close the popup.
+4. Keyboard focus remains inside the popup and returns to the opening card.
+5. Page scroll position does not jump after closing.
+6. The four album cards show **View Full Album**, and each button opens the same preexisting Google Photos destination.
+7. The other three cards do not show an album button.
+8. The header menu, custom-order section, checkout, and mobile layout still work.
+
+Expected: all eight checks pass before reporting publication complete.

--- a/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
+++ b/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
@@ -489,7 +489,7 @@ Expected: Wrangler validates and packages the `twisted` Worker without publishin
 
 ```bash
 git push -u origin codex/build1-featured-popup
-gh pr create --base main --head codex/build1-featured-popup --title "Add featured work photo popup" --body-file .superpowers/pr-body.md
+gh pr create --base main --head codex/build1-featured-popup --title "Add featured work photo popup" --body "Adds accessible larger-photo popups to the seven Featured Work cards while preserving the four existing Google Photos album links."
 gh pr merge --merge --delete-branch
 ```
 

--- a/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
+++ b/docs/superpowers/plans/2026-08-01-featured-work-photo-popup.md
@@ -155,7 +155,7 @@ git commit -m "test: define featured work lightbox behavior"
 
 **Interfaces:**
 - Consumes: the four pure functions from Task 1.
-- Consumes: `FeaturedWorkItem[]` with `src`, `alt`, `title`, `category`, `width`, `height`, optional `position`, optional `href`, and optional `span`.
+- Produces: exported `FeaturedWorkItem` with `src`, `alt`, `title`, `category`, `width`, `height`, optional `position`, optional `href`, and optional `span`.
 - Produces: `FeaturedWorkLightbox({ items }: { items: FeaturedWorkItem[] })`.
 
 - [ ] **Step 1: Append a failing component-contract test**
@@ -197,13 +197,24 @@ Implement these exact behaviors in `FeaturedWorkLightbox.tsx`:
 
 import Image from 'next/image';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
-import type { FeaturedWorkItem } from '@/components/FeaturedWork';
 import {
   nextFeaturedFocusIndex,
   nextFeaturedPhoto,
   openFeaturedPhoto,
   previousFeaturedPhoto,
 } from '@/components/featuredWorkLightboxModel';
+
+export type FeaturedWorkItem = {
+  src: string;
+  alt: string;
+  title: string;
+  category: string;
+  width: number;
+  height: number;
+  span?: string;
+  position?: string;
+  href?: string;
+};
 
 const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
 
@@ -375,7 +386,7 @@ git commit -m "feat: add accessible featured work photo popup"
 - Modify: `scripts/featured-work-lightbox.test.cjs`
 
 **Interfaces:**
-- Produces: exported `FeaturedWorkItem` type consumed by Task 2.
+- Consumes: exported `FeaturedWorkItem` type from Task 2.
 - Passes: the unchanged `featuredWork` array to `<FeaturedWorkLightbox items={featuredWork} />`.
 
 - [ ] **Step 1: Append a failing integration test**
@@ -410,19 +421,7 @@ Expected: the integration test FAILS because `FeaturedWork.tsx` does not yet del
 At the top of `FeaturedWork.tsx`, remove the now-unused `Image` import and add:
 
 ```tsx
-import FeaturedWorkLightbox from '@/components/FeaturedWorkLightbox';
-
-export type FeaturedWorkItem = {
-  src: string;
-  alt: string;
-  title: string;
-  category: string;
-  width: number;
-  height: number;
-  span?: string;
-  position?: string;
-  href?: string;
-};
+import FeaturedWorkLightbox, { type FeaturedWorkItem } from '@/components/FeaturedWorkLightbox';
 ```
 
 Change the existing array declaration from `const featuredWork = [` to `const featuredWork: FeaturedWorkItem[] = [`. Leave every one of the seven existing object literals byte-for-byte unchanged.

--- a/docs/superpowers/specs/2026-08-01-featured-work-photo-popup-design.md
+++ b/docs/superpowers/specs/2026-08-01-featured-work-photo-popup-design.md
@@ -1,0 +1,81 @@
+# Featured Work Photo Popup Design
+
+## Goal
+
+Let visitors enlarge every photo in the seven-card **Featured Leather Work** section without replacing or rolling back the current website. Preserve the four existing Google Photos album links by presenting them as an explicit action inside the popup.
+
+## Scope
+
+- Make all seven Featured Work cards open a large photo popup.
+- Show the same source image used by the selected card, without cropping it.
+- Show the card title and category in the popup.
+- Provide Previous and Next navigation through all seven photos, wrapping from the first to the last and from the last to the first.
+- Support keyboard Left Arrow, Right Arrow, and Escape controls.
+- Close from the close button or the shaded backdrop.
+- Show a **View Full Album** button only for the four cards that already have Google Photos links.
+- Keep the header menu, album destinations, custom-order section, and all other current site content unchanged.
+
+## User Experience
+
+Each Featured Work card behaves like a button. Selecting it opens a centered, responsive overlay above the page. The selected image is displayed at the largest practical size with `object-contain`, so the full image remains visible on phones and computers. The title, category, navigation controls, close control, and optional album button remain readable without covering important parts of the image.
+
+The album button opens the existing Google Photos destination in a new tab. Closing the popup returns keyboard focus to the card that opened it.
+
+## Architecture
+
+### Featured Work data
+
+Keep the seven existing entries and image sources in `FeaturedWork.tsx`. The current `href` values remain the source of truth for optional album buttons. The cards pass their index into the popup state rather than navigating directly when selected.
+
+### Popup component
+
+Add a focused client component responsible for:
+
+- the active photo index;
+- rendering the overlay and selected photo;
+- Previous, Next, close, backdrop, and keyboard behavior;
+- body scroll locking while open;
+- focus placement, focus trapping, and focus restoration;
+- the conditional Google Photos album action.
+
+The component receives the photo list and selected index through a small, clear interface. Pure navigation calculations should remain separate and independently testable.
+
+### Data flow
+
+1. A visitor selects a Featured Work card.
+2. `FeaturedWork` stores the selected index and opens the popup.
+3. The popup reads the matching item and renders its image and metadata.
+4. Navigation changes the selected index within the same seven-item list.
+5. Closing clears the active selection and restores the page state and focus.
+
+## Accessibility and Error Handling
+
+- Use an accessible dialog with a clear label.
+- Give all icon controls descriptive labels.
+- Trap keyboard focus inside the open dialog and restore it on close.
+- Prevent the page behind the popup from scrolling or receiving focus while the popup is open.
+- Preserve alternative text for every image.
+- If an image fails to load, the dialog remains closable and its title, navigation, and album action remain usable.
+- External album links keep `noopener noreferrer` protection.
+
+## Testing
+
+Automated tests will verify:
+
+- all seven cards participate in the popup;
+- first/last navigation wraps correctly;
+- Escape and arrow-key behavior is wired in;
+- close, backdrop, focus restoration, and scroll restoration contracts are present;
+- album buttons appear only when an item has an existing album URL;
+- current Google Photos URLs remain unchanged.
+
+The full project type check, production build, and Cloudflare deployment dry run must pass before publishing. After deployment, verify the live home page on desktop and mobile widths, open multiple cards, navigate between photos, follow an album button, and close the popup in each supported way.
+
+## Acceptance Criteria
+
+- Every Featured Work card opens its own larger, uncropped image.
+- Previous and Next navigation reaches all seven images and wraps correctly.
+- The popup works with mouse, touch, and keyboard controls.
+- Four album cards retain access to their current Google Photos albums through **View Full Album**.
+- No existing menu item, album URL, card image, or unrelated page content changes.
+- Tests, type checks, the production build, and live smoke checks pass.

--- a/scripts/featured-work-lightbox.test.cjs
+++ b/scripts/featured-work-lightbox.test.cjs
@@ -43,3 +43,23 @@ test('featured popup focus cycles and recovers outside focus', () => {
   assert.equal(model.nextFeaturedFocusIndex(-1, 3, true), 2);
   assert.equal(model.nextFeaturedFocusIndex(0, 0, false), null);
 });
+
+test('featured work popup exposes accessible controls and the optional album action', () => {
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  assert.match(component, /'use client'/);
+  assert.match(component, /role="dialog"/);
+  assert.match(component, /aria-modal="true"/);
+  assert.match(component, /aria-label="Close larger image"/);
+  assert.match(component, /aria-label="Previous image"/);
+  assert.match(component, /aria-label="Next image"/);
+  assert.match(component, /View Full Album/);
+  assert.match(component, /selectedItem\.href/);
+  assert.match(component, /event\.key === 'Escape'/);
+  assert.match(component, /event\.key === 'ArrowLeft'/);
+  assert.match(component, /event\.key === 'ArrowRight'/);
+  assert.match(component, /object-contain/);
+  assert.match(component, /document\.body\.style\.overflow = 'hidden'/);
+  assert.match(component, /sibling\.setAttribute\('inert', ''\)/);
+  assert.match(component, /window\.scrollTo/);
+  assert.match(component, /opener\?\.focus\(\)/);
+});

--- a/scripts/featured-work-lightbox.test.cjs
+++ b/scripts/featured-work-lightbox.test.cjs
@@ -63,3 +63,20 @@ test('featured work popup exposes accessible controls and the optional album act
   assert.match(component, /window\.scrollTo/);
   assert.match(component, /opener\?\.focus\(\)/);
 });
+
+test('all seven featured cards use the popup and existing album links remain unchanged', () => {
+  const featured = read('src/components/FeaturedWork.tsx');
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  const hrefs = [...featured.matchAll(/href: '([^']+)'/g)].map((match) => match[1]);
+  assert.match(featured, /import FeaturedWorkLightbox/);
+  assert.match(featured, /<FeaturedWorkLightbox items=\{featuredWork\} \/>/);
+  assert.equal((featured.match(/title: '/g) || []).length, 7);
+  assert.deepEqual(hrefs, [
+    'https://photos.app.goo.gl/GpcrR32WbqrkSV4L7',
+    'https://photos.google.com/share/AF1QipOsNxODm1-e7A7G3G6ZEPn-cshXXMuZRXZXyykPdt4nqefNbiUnD5bRCaW32J-fsg?key=RFJLS0hBckVXTmpubFdBU0xGbzNjSWFiXzR2VnVn',
+    'https://photos.google.com/share/AF1QipPzOOqKXTMznO6pcbD_tzOVFen160_3j2S1ndp848nNXufyX3sKbKXxPNT_lbFSwA/photo/AF1QipMAfvfW-Iggd2w43t0R_LjXdGapeanTWw0qlyfS?key=QWpuY19GY1BIWWg0bndnZnFRdmY1bmZNME40RDl3',
+    'https://photos.app.goo.gl/LTtAmZFpcWxB893j2',
+  ]);
+  assert.match(component, /target="_blank"/);
+  assert.match(component, /rel="noopener noreferrer"/);
+});

--- a/scripts/featured-work-lightbox.test.cjs
+++ b/scripts/featured-work-lightbox.test.cjs
@@ -1,0 +1,45 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+const root = path.resolve(__dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+
+function loadTypeScriptModule(file) {
+  const javascript = ts.transpileModule(read(file), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020 },
+  }).outputText;
+  const sandbox = { exports: {}, module: { exports: {} } };
+  sandbox.module.exports = sandbox.exports;
+  vm.runInNewContext(javascript, sandbox, { filename: file });
+  return sandbox.exports;
+}
+
+test('opens only valid featured photos', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.openFeaturedPhoto(7, 0), 0);
+  assert.equal(model.openFeaturedPhoto(7, 6), 6);
+  assert.equal(model.openFeaturedPhoto(7, -1), null);
+  assert.equal(model.openFeaturedPhoto(7, 7), null);
+  assert.equal(model.openFeaturedPhoto(0, 0), null);
+});
+
+test('featured photo navigation wraps in both directions', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.nextFeaturedPhoto(6, 7), 0);
+  assert.equal(model.previousFeaturedPhoto(0, 7), 6);
+  assert.equal(model.nextFeaturedPhoto(2, 7), 3);
+  assert.equal(model.previousFeaturedPhoto(2, 7), 1);
+});
+
+test('featured popup focus cycles and recovers outside focus', () => {
+  const model = loadTypeScriptModule('src/components/featuredWorkLightboxModel.ts');
+  assert.equal(model.nextFeaturedFocusIndex(2, 3, false), 0);
+  assert.equal(model.nextFeaturedFocusIndex(0, 3, true), 2);
+  assert.equal(model.nextFeaturedFocusIndex(-1, 3, false), 0);
+  assert.equal(model.nextFeaturedFocusIndex(-1, 3, true), 2);
+  assert.equal(model.nextFeaturedFocusIndex(0, 0, false), null);
+});

--- a/scripts/featured-work-lightbox.test.cjs
+++ b/scripts/featured-work-lightbox.test.cjs
@@ -64,6 +64,18 @@ test('featured work popup exposes accessible controls and the optional album act
   assert.match(component, /opener\?\.focus\(\)/);
 });
 
+test('featured popup lifecycle runs only when the popup opens or closes', () => {
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  assert.match(component, /const isOpen = selectedItem !== null;/);
+  assert.match(component, /useEffect\(\(\) => \{\s+if \(!isOpen\) return;[\s\S]*?\}, \[isOpen\]\);/);
+});
+
+test('featured card buttons do not nest articles', () => {
+  const component = read('src/components/FeaturedWorkLightbox.tsx');
+  assert.doesNotMatch(component, /className="group text-left[\s\S]*?<article\b/);
+  assert.match(component, /className=\{`relative overflow-hidden rounded-lg border border-copper\/30 bg-wood-dark\/60 min-h-\[18rem\] \$\{item\.span \?\? ''\}`\}/);
+});
+
 test('all seven featured cards use the popup and existing album links remain unchanged', () => {
   const featured = read('src/components/FeaturedWork.tsx');
   const component = read('src/components/FeaturedWorkLightbox.tsx');

--- a/src/components/FeaturedWork.tsx
+++ b/src/components/FeaturedWork.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image';
+import FeaturedWorkLightbox, { type FeaturedWorkItem } from '@/components/FeaturedWorkLightbox';
 
-const featuredWork = [
+const featuredWork: FeaturedWorkItem[] = [
 	{
 		src: 'https://lh3.googleusercontent.com/pw/AP1GczPM9XIkZnxqrfQIgXv7yF7vDC2g4VhSlAPzsXu_YRmwUiVRtEaZefpRKuxp7sj9KUbOoM771elbKB6RksdC5m4byxM_F5RZ3MOTjDQd3JbJ8D-SKLfRvmq7V17KVa1ySQMOqysjcTpJKXtCSVxsSnjrcg7oUh2RKSPr4BqAMfVrQPoQXK2pnOZhVF8q6FehjpAYQdDa5yUAtQjle3u9pi3sKgMtD0gwAlu89y2E_knZ78SvhjbTfFIzFTPwIwY8_Uei1QTQSNUsuisv94ZCl4pcwiT7Iv33P8KTlEnqW1wlxL2-pE2UXIIj-GvEBrdnTLLClZc5gG5uaoL9eyMk_SR9z3PsVbQ2jxNHZlG3k_GyuE97qDhn-tlauUakG6cNircphT_-w03oykcqboYHycuycXbZCQ3ORUSuiG2ybkDuZdvX1x-j7Hvhr6Z1U_17U5OyzQRj2rO7zE1aG7wkF_TLy-5d-Jkc5zuhqp7f7KSKt6wthQ7p-CxqMVMDqWi37W7miZ5NzSTdTKfjWMW4lp8GxIGsIHsgDP4OL6G6hJn9ZtWoGXSTbTGXvybZseB43PI3GcuVwXbFVF2VXqwt388IpBQfZSshT7nr5WsWaVBh90_P1_t_QVqILTivcGeoWtiJOblNMfj0qm3hV_YVNA5HGfW4E-nQAq1L2lTvyJjYYEXZWecpw2cBlE0EAyYuSwuZyXzdgffpJ-KQcFfmDeZJpz-Ef2AKlEyEqP5z_E-R2NwxuUd5EyEthyV8M7h164mbmLARRXdA05jhjQN1M9gjhzAGMfKAimpO79PEJL8bowuvuP64B2NGfZLSF2mFm22tL0MiHsK8Hdh-aSw9Z4xlT3YhdAhVBvRF1X6R4GGYZ9vrrqSwH2pbzqWfWfS5TIMm91JWNCZ3XCFxCkORhGY7n2k0-d9YXjH-DmvTuXBYXaTo9Wqn6JIo3UjdBK845de09Ixwio7is9YA2ObjZeVwI6wZuI4exUcHqS_yU0bwnIYj-w=w401-h301-no',
 		alt: 'Custom tooled leather portfolio cover with floral tooling and a name panel',
@@ -96,65 +96,7 @@ export default function FeaturedWork() {
 					</a>
 				</div>
 
-				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5">
-					{featuredWork.map((item) => {
-						const isExternalImage = item.src.startsWith('http');
-						const imageClassName = "absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105";
-						const card = (
-							<article
-								className={`group relative overflow-hidden rounded-lg border border-copper/30 bg-wood-dark/60 min-h-[18rem] ${item.span}`}
-							>
-								{isExternalImage ? (
-									<img
-										src={item.src}
-										alt={item.alt}
-										className={imageClassName}
-										style={{ objectPosition: item.position ?? 'center' }}
-									/>
-								) : (
-									<Image
-										src={item.src}
-										alt={item.alt}
-										width={item.width}
-										height={item.height}
-										className={imageClassName}
-										style={{ objectPosition: item.position ?? 'center' }}
-										sizes={item.span ? '(max-width: 1024px) 100vw, 50vw' : '(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw'}
-									/>
-								)}
-								<div className="absolute inset-0 bg-gradient-to-t from-wood-dark/80 via-wood-dark/10 to-transparent" />
-								<div className="absolute left-4 right-4 bottom-4">
-									<p className="text-copper-light text-sm font-bold uppercase">
-										{item.category}
-									</p>
-									<h3 className="heading-western text-2xl text-cream">
-										{item.title}
-									</h3>
-								</div>
-							</article>
-						);
-
-						if (item.href) {
-							return (
-								<a
-									key={item.title}
-									href={item.href}
-									target="_blank"
-									rel="noopener noreferrer"
-									aria-label={`Open ${item.title}`}
-								>
-									{card}
-								</a>
-							);
-						}
-
-						return (
-							<div key={item.title}>
-								{card}
-							</div>
-						);
-					})}
-				</div>
+				<FeaturedWorkLightbox items={featuredWork} />
 			</div>
 		</section>
 	);

--- a/src/components/FeaturedWorkLightbox.tsx
+++ b/src/components/FeaturedWorkLightbox.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import Image from 'next/image';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import {
+  nextFeaturedFocusIndex,
+  nextFeaturedPhoto,
+  openFeaturedPhoto,
+  previousFeaturedPhoto,
+} from '@/components/featuredWorkLightboxModel';
+
+export type FeaturedWorkItem = {
+  src: string;
+  alt: string;
+  title: string;
+  category: string;
+  width: number;
+  height: number;
+  position?: string;
+  href?: string;
+  span?: string;
+};
+
+const focusableSelector = 'button:not([disabled]), [href], [tabindex]:not([tabindex="-1"])';
+
+type BackgroundState = {
+  element: HTMLElement;
+  inert: boolean;
+  ariaHidden: string | null;
+};
+
+function makeBackgroundInert(dialog: HTMLElement) {
+  const states: BackgroundState[] = [];
+  let foreground: HTMLElement = dialog;
+  while (foreground.parentElement) {
+    const parent = foreground.parentElement;
+    for (const sibling of Array.from(parent.children)) {
+      if (sibling === foreground || !(sibling instanceof HTMLElement)) continue;
+      states.push({
+        element: sibling,
+        inert: sibling.hasAttribute('inert'),
+        ariaHidden: sibling.getAttribute('aria-hidden'),
+      });
+      sibling.setAttribute('inert', '');
+      sibling.setAttribute('aria-hidden', 'true');
+    }
+    if (parent === document.body) break;
+    foreground = parent;
+  }
+  return () => states.forEach(({ element, inert, ariaHidden }) => {
+    if (!inert) element.removeAttribute('inert');
+    if (ariaHidden === null) element.removeAttribute('aria-hidden');
+    else element.setAttribute('aria-hidden', ariaHidden);
+  });
+}
+
+export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkItem[] }) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const openerRef = useRef<HTMLButtonElement | null>(null);
+  const previousOverflow = useRef('');
+  const scrollPosition = useRef({ x: 0, y: 0 });
+  const captionId = useId();
+  const selectedItem = selectedIndex === null ? null : items[selectedIndex] ?? null;
+
+  const close = useCallback(() => {
+    const opener = openerRef.current;
+    setSelectedIndex(null);
+    openerRef.current = null;
+    requestAnimationFrame(() => {
+      opener?.focus();
+      window.scrollTo(scrollPosition.current.x, scrollPosition.current.y);
+    });
+  }, []);
+
+  const previous = useCallback(() => {
+    setSelectedIndex((current) => current === null ? null : previousFeaturedPhoto(current, items.length));
+  }, [items.length]);
+
+  const next = useCallback(() => {
+    setSelectedIndex((current) => current === null ? null : nextFeaturedPhoto(current, items.length));
+  }, [items.length]);
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    previousOverflow.current = document.body.style.overflow;
+    const restoreBackground = dialogRef.current ? makeBackgroundInert(dialogRef.current) : () => {};
+    document.body.style.overflow = 'hidden';
+    closeRef.current?.focus();
+    return () => {
+      document.body.style.overflow = previousOverflow.current;
+      restoreBackground();
+    };
+  }, [selectedItem]);
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+      if (event.key === 'ArrowLeft') previous();
+      if (event.key === 'ArrowRight') next();
+      if (event.key === 'Tab' && dialogRef.current) {
+        const focusable = Array.from(dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector));
+        const current = focusable.indexOf(document.activeElement as HTMLElement);
+        const target = nextFeaturedFocusIndex(current, focusable.length, event.shiftKey);
+        if (target !== null) {
+          event.preventDefault();
+          focusable[target].focus();
+        }
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [close, next, previous, selectedItem]);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-5">
+        {items.map((item, index) => (
+          <button
+            key={item.title}
+            type="button"
+            aria-label={`View larger: ${item.title}`}
+            onClick={(event) => {
+              const nextIndex = openFeaturedPhoto(items.length, index);
+              if (nextIndex === null) return;
+              openerRef.current = event.currentTarget;
+              scrollPosition.current = { x: window.scrollX, y: window.scrollY };
+              setSelectedIndex(nextIndex);
+            }}
+            className="group text-left cursor-zoom-in focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-copper"
+          >
+            <article className={`relative overflow-hidden rounded-lg border border-copper/30 bg-wood-dark/60 min-h-[18rem] ${item.span ?? ''}`}>
+              {item.src.startsWith('http') ? (
+                <img src={item.src} alt={item.alt} className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" style={{ objectPosition: item.position ?? 'center' }} />
+              ) : (
+                <Image src={item.src} alt={item.alt} width={item.width} height={item.height} className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" style={{ objectPosition: item.position ?? 'center' }} sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw" />
+              )}
+              <div className="absolute inset-0 bg-gradient-to-t from-wood-dark/80 via-wood-dark/10 to-transparent" />
+              <div className="absolute bottom-4 left-4 right-4">
+                <p className="text-copper-light text-sm font-bold uppercase">{item.category}</p>
+                <h3 className="heading-western text-2xl text-cream">{item.title}</h3>
+              </div>
+            </article>
+          </button>
+        ))}
+      </div>
+
+      {selectedItem && (
+        <div ref={dialogRef} role="dialog" aria-modal="true" aria-labelledby={captionId} onClick={(event) => { if (event.target === event.currentTarget) close(); }} className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 p-3 sm:p-6">
+          <button ref={closeRef} type="button" aria-label="Close larger image" onClick={close} className="absolute right-3 top-3 z-10 h-12 w-12 rounded-full border border-copper bg-charcoal/90 text-3xl text-cream">×</button>
+          <button type="button" aria-label="Previous image" onClick={previous} className="absolute left-2 top-1/2 z-10 h-14 w-12 -translate-y-1/2 rounded-full border border-copper bg-charcoal/90 text-4xl text-cream sm:left-5">‹</button>
+          <figure className="flex max-h-full max-w-6xl flex-col items-center gap-3 px-10 sm:px-16">
+            <img src={selectedItem.src} alt={selectedItem.alt} className="max-h-[calc(100vh-10rem)] max-w-full h-auto w-auto object-contain" />
+            <figcaption id={captionId} className="text-center">
+              <p className="text-copper-light text-sm font-bold uppercase">{selectedItem.category}</p>
+              <p className="heading-western text-xl text-cream">{selectedItem.title}</p>
+            </figcaption>
+            {selectedItem.href && <a href={selectedItem.href} target="_blank" rel="noopener noreferrer" className="rounded-lg bg-copper px-5 py-3 font-bold text-charcoal hover:bg-cream">View Full Album</a>}
+          </figure>
+          <button type="button" aria-label="Next image" onClick={next} className="absolute right-2 top-1/2 z-10 h-14 w-12 -translate-y-1/2 rounded-full border border-copper bg-charcoal/90 text-4xl text-cream sm:right-5">›</button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/FeaturedWorkLightbox.tsx
+++ b/src/components/FeaturedWorkLightbox.tsx
@@ -63,6 +63,7 @@ export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkIte
   const scrollPosition = useRef({ x: 0, y: 0 });
   const captionId = useId();
   const selectedItem = selectedIndex === null ? null : items[selectedIndex] ?? null;
+  const isOpen = selectedItem !== null;
 
   const close = useCallback(() => {
     const opener = openerRef.current;
@@ -83,7 +84,7 @@ export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkIte
   }, [items.length]);
 
   useEffect(() => {
-    if (!selectedItem) return;
+    if (!isOpen) return;
     previousOverflow.current = document.body.style.overflow;
     const restoreBackground = dialogRef.current ? makeBackgroundInert(dialogRef.current) : () => {};
     document.body.style.overflow = 'hidden';
@@ -92,7 +93,7 @@ export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkIte
       document.body.style.overflow = previousOverflow.current;
       restoreBackground();
     };
-  }, [selectedItem]);
+  }, [isOpen]);
 
   useEffect(() => {
     if (!selectedItem) return;
@@ -131,7 +132,7 @@ export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkIte
             }}
             className="group text-left cursor-zoom-in focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-copper"
           >
-            <article className={`relative overflow-hidden rounded-lg border border-copper/30 bg-wood-dark/60 min-h-[18rem] ${item.span ?? ''}`}>
+            <div className={`relative overflow-hidden rounded-lg border border-copper/30 bg-wood-dark/60 min-h-[18rem] ${item.span ?? ''}`}>
               {item.src.startsWith('http') ? (
                 <img src={item.src} alt={item.alt} className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" style={{ objectPosition: item.position ?? 'center' }} />
               ) : (
@@ -142,7 +143,7 @@ export default function FeaturedWorkLightbox({ items }: { items: FeaturedWorkIte
                 <p className="text-copper-light text-sm font-bold uppercase">{item.category}</p>
                 <h3 className="heading-western text-2xl text-cream">{item.title}</h3>
               </div>
-            </article>
+            </div>
           </button>
         ))}
       </div>

--- a/src/components/featuredWorkLightboxModel.ts
+++ b/src/components/featuredWorkLightboxModel.ts
@@ -1,0 +1,29 @@
+export type FeaturedPhotoIndex = number | null;
+
+export function openFeaturedPhoto(count: number, requestedIndex: number): FeaturedPhotoIndex {
+  return Number.isInteger(requestedIndex)
+    && requestedIndex >= 0
+    && requestedIndex < count
+    ? requestedIndex
+    : null;
+}
+
+export function previousFeaturedPhoto(currentIndex: number, count: number): FeaturedPhotoIndex {
+  return count > 0 ? (currentIndex - 1 + count) % count : null;
+}
+
+export function nextFeaturedPhoto(currentIndex: number, count: number): FeaturedPhotoIndex {
+  return count > 0 ? (currentIndex + 1) % count : null;
+}
+
+export function nextFeaturedFocusIndex(
+  currentIndex: number,
+  focusableCount: number,
+  moveBackward: boolean,
+): FeaturedPhotoIndex {
+  if (focusableCount <= 0) return null;
+  if (currentIndex < 0 || currentIndex >= focusableCount) {
+    return moveBackward ? focusableCount - 1 : 0;
+  }
+  return (currentIndex + (moveBackward ? -1 : 1) + focusableCount) % focusableCount;
+}


### PR DESCRIPTION
## What changed

- Make all seven Featured Leather Work cards open a larger, accessible photo popup.
- Add Previous and Next navigation with wraparound, keyboard controls, focus trapping, focus restoration, and background scroll locking.
- Preserve the four existing Google Photos album links as optional “View Full Album” actions.
- Keep the existing card imagery, categories, titles, header navigation, custom-order section, and unrelated pages unchanged.

## Customer impact

Visitors can inspect portfolio photos without leaving the homepage, while still opening the full albums when available.

## Validation

- 7/7 focused behavior tests pass.
- TypeScript check passes.
- Next.js production build completes and generates all 18 routes.
- `git diff --check` passes.
- Independent whole-branch review found no remaining critical, important, or minor issues.