### PR TITLE
Hide routine Cloudflare verification panel

### DIFF
--- a/scripts/custom-order-rendered-interactions.test.cjs
+++ b/scripts/custom-order-rendered-interactions.test.cjs
@@ -1,3 +1,4 @@
+
 const assert = require('node:assert/strict');
 const test = require('node:test');
 const React = require('react');
@@ -93,6 +94,7 @@ test('Turnstile expiry defeats a late upload response and checkout submits recov
     render(React.createElement(Assistant));
     fireEvent.click(screen.getByRole('button', { name: /Continue to customization/i }));
     await waitFor(() => assert.ok(turnstileOptions));
+    assert.equal(turnstileOptions.appearance, 'interaction-only');
     act(() => turnstileOptions.callback('turnstile-token-1'));
     const file = new File(['image bytes'], 'sketch.jpg', { type: 'image/jpeg' });
     fireEvent.change(screen.getByLabelText(/Choose reference images/i), { target: { files: [file] } });

--- a/src/components/custom-order/TurnstileWidget.tsx
+++ b/src/components/custom-order/TurnstileWidget.tsx
@@ -1,3 +1,4 @@
+
 'use client';
 
 import Script from 'next/script';
@@ -35,6 +36,7 @@ export default function TurnstileWidget({ siteKey, resetNonce, disabled, onToken
 		widgetIdRef.current = window.turnstile.render(containerRef.current, {
 			sitekey: siteKey,
 			action: TURNSTILE_ACTION,
+			appearance: 'interaction-only',
 			callback: (token: string) => callbacksRef.current.onToken(token),
 			'expired-callback': () => callbacksRef.current.onExpired(),
 			'error-callback': () => callbacksRef.current.onError(),


### PR DESCRIPTION
## What changed

- configure the existing Cloudflare Turnstile widget with `appearance: "interaction-only"`
- add a rendered interaction regression assertion for the configuration

## Why

The default Turnstile appearance displayed a branded success panel at the top of the first custom-order step. Interaction-only mode keeps early verification active for protected uploads and checkout while hiding the panel unless Cloudflare requires visitor interaction.

## Validation

- focused rendered interaction test: 3 passed
- full project suite: 144 passed
- TypeScript check: passed
- generated Cloudflare types check: passed
- production OpenNext build will run in Cloudflare's clean Linux build environment before deployment